### PR TITLE
#77 Fix file path formatting in OpenIDE method call

### DIFF
--- a/UI/MainWindows/MainWindowViewModel.cs
+++ b/UI/MainWindows/MainWindowViewModel.cs
@@ -242,7 +242,7 @@ namespace UI.MainWindows
                 new()
                 {
                     FileName = devAppPath,
-                    Arguments = $"{fullFilePath}",
+                    Arguments = $"\"{fullFilePath}\"",
                     UseShellExecute = true,
                 }
             );


### PR DESCRIPTION
Updated the `Arguments` property in `MainWindowViewModel.cs` to wrap `fullFilePath` in double quotes. This change ensures proper handling of file paths with spaces, preventing potential execution issues. #77

Related Work Items: #72