### PR TITLE
Add IDEPathId to Project initialization

### DIFF
--- a/UI/Features/Projects/ProjectsWindowViewModel.cs
+++ b/UI/Features/Projects/ProjectsWindowViewModel.cs
@@ -123,7 +123,7 @@ public class ProjectsWindowViewModel : ViewModelBase
         string filePath = openFolderDialog.FolderName;
         string name = string.IsNullOrEmpty(Project!.Name) ? openFolderDialog.SafeFolderName : Project.Name;
 
-        Project = new() { Id = Project?.Id ?? 0, Path = filePath, Name = name! };
+        Project = new() { Id = Project?.Id ?? 0, Path = filePath, Name = name!, IDEPathId = SelectedDevApp!.Id };
     }
 
     private void AddNew()


### PR DESCRIPTION
This pull request makes a small update to the `OpenDialog` method in `ProjectsWindowViewModel.cs` to ensure that the newly created `Project` object includes the selected development application's ID.

* The `Project` object now sets its `IDEPathId` property to the value of `SelectedDevApp.Id` when a new project is created or updated in `OpenDialog`.