### PR TITLE
Update LoadProjects to use current search value

### DIFF
--- a/UI/MainWindows/MainWindowViewModel.cs
+++ b/UI/MainWindows/MainWindowViewModel.cs
@@ -280,7 +280,7 @@ namespace UI.MainWindows
 
         public void LoadProjects()
         {
-            SearchProjects("");
+            SearchProjects(this.Search);
         }
     }
 }


### PR DESCRIPTION
This pull request updates the `LoadProjects` method in `MainWindowViewModel.cs` to use the current search term instead of always resetting to an empty string. This ensures that when projects are loaded, the user's search filter is preserved.