### PR TITLE
Edit Project  | Add project selection service and refactor UI components

### DIFF
--- a/Tests/ApplicationCoreTests/UI/MainWindowViewModelTests.cs
+++ b/Tests/ApplicationCoreTests/UI/MainWindowViewModelTests.cs
@@ -1,0 +1,86 @@
+using ApplicationCore.Features.Projects;
+using Moq;
+using UI.MainWindows;
+using UI.Features;
+using UI.Shared.Services;
+using ApplicationCore.Common;
+using Xunit;
+using UI.Features.Projects;
+using ApplicationCore.Features.DevApps;
+
+namespace ApplicationCoreTests.UI
+{
+    public class MainWindowViewModelTests
+    {
+        private class TestableMainWindowViewModel : MainWindowViewModel
+        {
+            public bool ShowCalled { get; private set; }
+            public IProjectsWindow? PassedWindow { get; private set; }
+
+            public TestableMainWindowViewModel(IProjectService projectService,
+                INotificationMessageService notificationMessageService,
+                IServiceProvider serviceProvider,
+                ISelectedProjectService selectedProjectService)
+                : base(projectService, notificationMessageService, serviceProvider, selectedProjectService)
+            { }
+
+            protected override void ShowProjectsWindow(IProjectsWindow window)
+            {
+                ShowCalled = true;
+                PassedWindow = window;
+            }
+        }
+
+        [Fact]
+        public void EditCommand_SetsSelectedProject_And_ShowsProjectsWindow()
+        {
+            var projectService = new Mock<IProjectService>();
+            var notificationService = new Mock<INotificationMessageService>();
+            var selectedProjectService = new SelectedProjectService();
+            var windowEventsService = new Mock<IProjectWindowEventsService>();
+            var devAppService = new Mock<IDevAppService>();
+            devAppService.Setup(d => d.GetAll()).ReturnsAsync([]);
+            projectService.Setup(p => p.GetOne(It.IsAny<long>()))
+                .ReturnsAsync((long id) => new ProjectViewModel { Id = id, Name = "Proj", Path = "c:/p", IDEPathId = 2 });
+
+            // Create a mock implementing IProjectsWindow without needing concrete WPF window
+            var projectsWindowMock = new Mock<IProjectsWindow>();
+            projectsWindowMock.Setup(w => w.ShowDialog()).Returns(true);
+
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider.Setup(sp => sp.GetService(typeof(IProjectsWindow))).Returns(projectsWindowMock.Object);
+
+            var vm = new TestableMainWindowViewModel(projectService.Object, notificationService.Object, serviceProvider.Object, selectedProjectService);
+            var existing = new ProjectViewModel { Id = 7, Name = "Proj", Path = "c:/p", IDEPathId = 2 };
+            vm.SelectedProject = existing;
+
+            vm.EditCommand.Execute(null);
+
+            var stored = selectedProjectService.GetSelectedProject();
+            Assert.Equal(existing.Id, stored.Id);
+            Assert.Equal(existing.Name, stored.Name);
+            Assert.True(vm.ShowCalled);
+            Assert.NotNull(vm.PassedWindow);
+        }
+
+        [Fact]
+        public void EditCommand_DoesNothing_When_NoWindowResolved()
+        {
+            var projectService = new Mock<IProjectService>();
+            projectService.Setup(p => p.GetOne(It.IsAny<long>()))
+                .ReturnsAsync((long id) => new ProjectViewModel { Id = id, Name = "A", Path = "c:/a" });
+            var notificationService = new Mock<INotificationMessageService>();
+            var selectedProjectService = new SelectedProjectService();
+
+            var serviceProvider = new Mock<IServiceProvider>();
+            serviceProvider.Setup(sp => sp.GetService(typeof(IProjectsWindow))).Returns(null);
+
+            var vm = new TestableMainWindowViewModel(projectService.Object, notificationService.Object, serviceProvider.Object, selectedProjectService);
+            vm.SelectedProject = new ProjectViewModel { Id = 1, Name = "A", Path = "c:/a" };
+
+            vm.EditCommand.Execute(null);
+
+            Assert.False(vm.ShowCalled);
+        }
+    }
+}

--- a/Tests/ApplicationCoreTests/UI/ProjectsWindowViewModelTests.cs
+++ b/Tests/ApplicationCoreTests/UI/ProjectsWindowViewModelTests.cs
@@ -1,0 +1,99 @@
+using System.Collections.ObjectModel;
+using ApplicationCore.Features.Projects;
+using ApplicationCore.Features.DevApps;
+using ApplicationCore.Common;
+using Moq;
+using UI.Features.Projects;
+using UI.Shared.Services;
+using Xunit;
+
+namespace ApplicationCoreTests.UI
+{
+    public class ProjectsWindowViewModelTests
+    {
+        private ProjectsWindowViewModel CreateSut(ProjectViewModel selectedProject,
+            out Mock<ISelectedProjectService> selectedProjectService,
+            out Mock<IProjectService> projectService,
+            out Mock<INotificationMessageService> notificationService,
+            out Mock<IProjectWindowEventsService> windowEventsService,
+            out Mock<IDevAppService> devAppService)
+        {
+            selectedProjectService = new Mock<ISelectedProjectService>();
+            projectService = new Mock<IProjectService>();
+            notificationService = new Mock<INotificationMessageService>();
+            windowEventsService = new Mock<IProjectWindowEventsService>();
+            devAppService = new Mock<IDevAppService>();
+
+            selectedProjectService.Setup(s => s.GetSelectedProject()).Returns(selectedProject);
+
+            var vm = new ProjectsWindowViewModel(projectService.Object,
+                notificationService.Object,
+                windowEventsService.Object,
+                devAppService.Object,
+                selectedProjectService.Object);
+
+            // ensure DevApps is non-null to prevent NullReference in Project setter logic
+            vm.DevApps = new ObservableCollection<DevAppViewModel>();
+
+            return vm;
+        }
+
+        [Fact]
+        public void SetSelectedProject_WhenServiceReturnsProject_SetsProjectAndSelectedDevApp()
+        {
+            var project = new ProjectViewModel
+            {
+                Id = 10,
+                Name = "TestProj",
+                Path = "c:/test",
+                IDEPathId = 5,
+                Filename = "test.sln"
+            };
+
+            var vm = CreateSut(project,
+                out var selectedProjectService,
+                out var projectService,
+                out var notificationService,
+                out var windowEventsService,
+                out var devAppService);
+
+            // Provide matching DevApp so SelectedDevApp can be set in Project setter
+            vm.DevApps = new ObservableCollection<DevAppViewModel>
+            {
+                new() { Id = 5, Name = "IDE", Path = "c:/ide.exe" }
+            };
+
+            vm.SetSelectedProject();
+
+            Assert.NotNull(vm.Project);
+            Assert.Equal(project.Id, vm.Project!.Id);
+            Assert.Equal(project.Name, vm.Project.Name);
+            Assert.False(ReferenceEquals(project, vm.Project)); // deep copy expected
+            Assert.NotNull(vm.SelectedDevApp);
+            Assert.Equal(5, vm.SelectedDevApp!.Id);
+        }
+
+        [Fact]
+        public void SetSelectedProject_WhenServiceReturnsNull_DoesNotChangeProject()
+        {
+            var initial = new ProjectViewModel { Id = 1, Name = "Initial", Path = "c:/init" }; // existing state
+            var vm = CreateSut(null!,
+                out var selectedProjectService,
+                out var projectService,
+                out var notificationService,
+                out var windowEventsService,
+                out var devAppService);
+
+            // Seed current project
+            vm.Project = initial;
+
+            // Override service to return null
+            selectedProjectService.Setup(s => s.GetSelectedProject()).Returns((ProjectViewModel)null!);
+
+            vm.SetSelectedProject();
+
+            Assert.Equal(initial.Id, vm.Project!.Id);
+            Assert.Equal(initial.Name, vm.Project.Name);
+        }
+    }
+}

--- a/Tests/ApplicationCoreTests/UI/SelectedProjectServiceTests.cs
+++ b/Tests/ApplicationCoreTests/UI/SelectedProjectServiceTests.cs
@@ -1,0 +1,63 @@
+using ApplicationCore.Features.Projects;
+using UI.Shared.Services;
+using Xunit;
+
+namespace ApplicationCoreTests.UI
+{
+    public class SelectedProjectServiceTests
+    {
+        [Fact]
+        public void GetSelectedProject_Default_ReturnsNewInstance()
+        {
+            var sut = new SelectedProjectService();
+
+            var result = sut.GetSelectedProject();
+
+            Assert.NotNull(result);
+            Assert.Equal(0, result.Id);
+            Assert.Equal(string.Empty, result.Name);
+            Assert.Equal(string.Empty, result.Path);
+        }
+
+        [Fact]
+        public void SetSelectedProject_ThenGet_ReturnsSameReference()
+        {
+            var sut = new SelectedProjectService();
+            var project = new ProjectViewModel
+            {
+                Id = 42,
+                Name = "Example",
+                Path = "c:/example",
+                IDEPathId = 7,
+                Filename = "example.sln",
+                DevAppName = "VS"
+            };
+
+            sut.SetSelectedProject(project);
+            var result = sut.GetSelectedProject();
+
+            Assert.Same(project, result); // service stores reference
+            Assert.Equal(42, result.Id);
+            Assert.Equal("Example", result.Name);
+            Assert.Equal("c:/example", result.Path);
+            Assert.Equal(7, result.IDEPathId);
+            Assert.Equal("example.sln", result.Filename);
+        }
+
+        [Fact]
+        public void MutatingReturnedProject_AffectsStoredProject()
+        {
+            var sut = new SelectedProjectService();
+            var project = new ProjectViewModel { Id = 1, Name = "Initial", Path = "c:/init" };
+            sut.SetSelectedProject(project);
+
+            // mutate after setting
+            project.Name = "Changed";
+            project.Path = "d:/changed";
+
+            var result = sut.GetSelectedProject();
+            Assert.Equal("Changed", result.Name);
+            Assert.Equal("d:/changed", result.Path);
+        }
+    }
+}

--- a/UI/App.xaml.cs
+++ b/UI/App.xaml.cs
@@ -12,6 +12,7 @@ using UI.DevApps;
 using UI.Features;
 using UI.Features.Projects;
 using UI.MainWindows;
+using UI.Shared.Services;
 
 namespace UI
 {
@@ -65,7 +66,7 @@ namespace UI
             return services
                 .AddSingleton<MainWindow>()
                 .AddTransient<DevAppsWindow>()
-                .AddTransient<ProjectsWindow>()
+                .AddTransient<IProjectsWindow, ProjectsWindow>()
                 .AddTransient<DevAppsWindowViewModel>()
                 .AddTransient<ProjectsWindowViewModel>()
                 .AddTransient<MainWindowViewModel>()
@@ -90,6 +91,7 @@ namespace UI
                 .AddSingleton<IGitService, GitService>()
                 .AddSingleton<IGroupService, GroupService>()
 
+                .AddSingleton<ISelectedProjectService, SelectedProjectService>()
                 .BuildServiceProvider();
         }
     }

--- a/UI/Features/Projects/ProjectsWindow.xaml.cs
+++ b/UI/Features/Projects/ProjectsWindow.xaml.cs
@@ -5,10 +5,15 @@ using UI.Features.Projects;
 
 namespace UI.Features
 {
+    public interface IProjectsWindow
+    {
+        bool? ShowDialog();
+    }
+
     /// <summary>
     /// Interaction logic for ProjectsWindow.xaml
     /// </summary>
-    public partial class ProjectsWindow : Window
+    public partial class ProjectsWindow : Window, IProjectsWindow
     {
         private readonly ProjectsWindowViewModel viewModel;
 
@@ -42,6 +47,7 @@ namespace UI.Features
         {
             viewModel.LoadProjects();
             viewModel.LoadDevApps();
+            this.viewModel.SetSelectedProject();
         }
 
         private void ComboBox_PreviewTextInput(object sender, TextCompositionEventArgs e)

--- a/UI/Features/Projects/ProjectsWindowViewModel.cs
+++ b/UI/Features/Projects/ProjectsWindowViewModel.cs
@@ -8,6 +8,7 @@ using System.Collections.ObjectModel;
 using System.Windows;
 using System.Windows.Input;
 using UI.Shared;
+using UI.Shared.Services;
 
 namespace UI.Features.Projects;
 
@@ -91,13 +92,15 @@ public class ProjectsWindowViewModel : ViewModelBase
     private readonly INotificationMessageService notificationMessageService;
     private readonly IProjectWindowEventsService projectWindowEventsService;
     private readonly IDevAppService devAppService;
+    private readonly ISelectedProjectService selectedProjectService;
     private ObservableCollection<DevAppViewModel> devApps;
     private DevAppViewModel? devApp;
 
     public ProjectsWindowViewModel(IProjectService projectService,
         INotificationMessageService notificationMessageService,
         IProjectWindowEventsService projectWindowEventsService,
-        IDevAppService devAppService
+        IDevAppService devAppService,
+        ISelectedProjectService selectedProjectService
         )
     {
         DeleteCommand = new RelayCommand(param => DeleteItem((ProjectViewModel)param!));
@@ -108,6 +111,7 @@ public class ProjectsWindowViewModel : ViewModelBase
         this.notificationMessageService = notificationMessageService;
         this.projectWindowEventsService = projectWindowEventsService;
         this.devAppService = devAppService;
+        this.selectedProjectService = selectedProjectService;
     }
 
     private void OpenDialog()
@@ -271,5 +275,17 @@ public class ProjectsWindowViewModel : ViewModelBase
     public async void LoadDevApps()
     {
         this.DevApps = [.. await devAppService.GetAll()];
+    }
+
+    public void SetSelectedProject()
+    {
+        var selecteProject = this.selectedProjectService.GetSelectedProject();
+
+        if (selecteProject is null)
+        {
+            return;
+        }
+
+        this.Project = selecteProject;
     }
 }

--- a/UI/MainWindows/MainWindow.xaml
+++ b/UI/MainWindows/MainWindow.xaml
@@ -198,9 +198,9 @@
                 </Style>
                 <ContextMenu x:Key="ItemContextMenu">
                     <MenuItem
-                        x:Name="mnuAddToGroup"
-                        Header="Add to Group"
-                        IsEnabled="{Binding EnableAddToGroup}" />
+                        x:Name="mnuEdit"
+                        Command="{Binding DataContext.EditCommand, RelativeSource={RelativeSource AncestorType=Window}}"
+                        Header="Edit" />
                     <MenuItem
                         x:Name="mnuMoveUp"
                        Command="{Binding DataContext.MoveUpCommand, RelativeSource={RelativeSource AncestorType=Window}}"

--- a/UI/Shared/Services/SelectedProjectService.cs
+++ b/UI/Shared/Services/SelectedProjectService.cs
@@ -1,0 +1,30 @@
+﻿using ApplicationCore.Features.Projects;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UI.Shared.Services
+{
+    public interface ISelectedProjectService
+    {
+        ProjectViewModel GetSelectedProject();
+        void SetSelectedProject(ProjectViewModel project);
+    }
+
+    public class SelectedProjectService : ISelectedProjectService
+    {
+        private ProjectViewModel selectedProject = new();
+
+        public ProjectViewModel GetSelectedProject()
+        {
+            return this.selectedProject;
+        }
+
+        public void SetSelectedProject(ProjectViewModel project)
+        {
+            this.selectedProject = project;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new service for managing the selected project across the UI and refactors the main window and projects window logic to use this service. It also adds comprehensive unit tests for the new service and related view models, improving testability and separation of concerns. The most important changes are grouped below.

### Core Service Addition

* Added `ISelectedProjectService` and its implementation `SelectedProjectService` to manage the selected project state in a centralized, injectable manner.
* Registered `ISelectedProjectService` as a singleton in the DI container in `App.xaml.cs`.

### Main Window Refactoring

* Refactored `MainWindowViewModel` to depend on `ISelectedProjectService`, and added an `EditCommand` that sets the selected project and opens the projects window via DI using the new interface. The dialog opening logic is now virtual for easier testing. [[1]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aR11) [[2]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aR23) [[3]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aR33) [[4]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aL70-R78) [[5]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aR88) [[6]](diffhunk://#diff-2d929d3e2a3ee153c7873b60873c85541096daf568ee6f8d364aa3f1e3cc304aR97-R119)
* Updated DI registration to bind `IProjectsWindow` to `ProjectsWindow` for better abstraction and testability.
* Changed context menu in `MainWindow.xaml` to use the new `EditCommand`.

### Projects Window Refactoring

* Added `IProjectsWindow` interface and implemented it in `ProjectsWindow` to allow mocking in tests and DI resolution.
* Refactored `ProjectsWindowViewModel` to depend on `ISelectedProjectService` and added a `SetSelectedProject()` method to sync the selected project from the service. This method is called on window load. [[1]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67R11) [[2]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67R95-R103) [[3]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67R114) [[4]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67R279-R290) [[5]](diffhunk://#diff-1c5b54df61937ae04812ef526af0c8d37e86f4559c4c6aa23c1456232e992720R50)

### Unit Testing

* Added unit tests for `SelectedProjectService` to verify default behavior, reference semantics, and mutation effects.
* Added tests for `MainWindowViewModel` covering the edit command logic and DI-based dialog opening with mocks.
* Added tests for `ProjectsWindowViewModel` covering selected project synchronization and dev app selection logic.