### PR TITLE
Refactor project validation and add error handling for duplicate name…

### DIFF
--- a/Tests/ApplicationCoreTests/UI/SelectedProjectServiceTests.cs
+++ b/Tests/ApplicationCoreTests/UI/SelectedProjectServiceTests.cs
@@ -30,7 +30,7 @@ namespace ApplicationCoreTests.UI
                 Path = "c:/example",
                 IDEPathId = 7,
                 Filename = "example.sln",
-                DevAppName = "VS"
+                DevAppName = "VS",
             };
 
             sut.SetSelectedProject(project);
@@ -48,7 +48,12 @@ namespace ApplicationCoreTests.UI
         public void MutatingReturnedProject_AffectsStoredProject()
         {
             var sut = new SelectedProjectService();
-            var project = new ProjectViewModel { Id = 1, Name = "Initial", Path = "c:/init" };
+            var project = new ProjectViewModel
+            {
+                Id = 1,
+                Name = "Initial",
+                Path = "c:/init",
+            };
             sut.SetSelectedProject(project);
 
             // mutate after setting
@@ -58,6 +63,26 @@ namespace ApplicationCoreTests.UI
             var result = sut.GetSelectedProject();
             Assert.Equal("Changed", result.Name);
             Assert.Equal("d:/changed", result.Path);
+        }
+
+        [Fact]
+        public void Reset_SelectedProject()
+        {
+            var sut = new SelectedProjectService();
+            var project = new ProjectViewModel
+            {
+                Id = 1,
+                Name = "Initial",
+                Path = "c:/init",
+            };
+            sut.SetSelectedProject(project);
+
+            sut.Reset();
+
+            var result = sut.GetSelectedProject();
+            Assert.Equal(0, result.Id);
+            Assert.Equal(string.Empty, result.Name);
+            Assert.Equal(string.Empty, result.Path);
         }
     }
 }

--- a/UI/Features/Projects/ProjectsWindow.xaml.cs
+++ b/UI/Features/Projects/ProjectsWindow.xaml.cs
@@ -43,9 +43,9 @@ namespace UI.Features
             }
         }
 
-        private void Window_Loaded(object sender, RoutedEventArgs e)
+        private async void Window_Loaded(object sender, RoutedEventArgs e)
         {
-            viewModel.LoadDevApps();
+            await viewModel.LoadDevApps();
             this.viewModel.SetSelectedProject();
             viewModel.CloseWindowEvent += (s, args) => this.Close();
         }

--- a/UI/Features/Projects/ProjectsWindowViewModel.cs
+++ b/UI/Features/Projects/ProjectsWindowViewModel.cs
@@ -135,7 +135,7 @@ public class ProjectsWindowViewModel : ViewModelBase
     {
         try
         {
-            if (!ValidateFields())
+            if (!await ValidateFields())
             {
                 return;
             }
@@ -193,42 +193,69 @@ public class ProjectsWindowViewModel : ViewModelBase
         }
     }
 
-    private bool ValidateFields()
+    private async Task<bool> ValidateFields()
     {
-        if (Project == null)
+        try
+        {
+            var result = await projectService.GetAll();
+            if (Project == null)
+            {
+                this.notificationMessageService.Create(
+                    "Invalid Project data.",
+                    "Save Project",
+                    NotificationType.Error
+                );
+
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(Project.Name) || String.IsNullOrWhiteSpace(Project.Name))
+            {
+                this.notificationMessageService.Create(
+                    "Name is required!",
+                    "Save Project",
+                    NotificationType.Error
+                );
+
+                return false;
+            }
+
+            if (
+                result.Projects.FirstOrDefault(x => x.Name == Project.Name && x.Id != Project.Id)
+                != null
+            )
+            {
+                this.notificationMessageService.Create(
+                    "Name already exists!",
+                    "Save Project",
+                    NotificationType.Error
+                );
+
+                return false;
+            }
+
+            if (String.IsNullOrEmpty(Project.Path) || String.IsNullOrWhiteSpace(Project.Path))
+            {
+                this.notificationMessageService.Create(
+                    "Path is required!",
+                    "Save Project",
+                    NotificationType.Error
+                );
+
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex)
         {
             this.notificationMessageService.Create(
-                "Invalid Project data.",
-                "Save Project",
+                ex.Message,
+                "Validate Project",
                 NotificationType.Error
             );
-
             return false;
         }
-
-        if (String.IsNullOrEmpty(Project.Name) || String.IsNullOrWhiteSpace(Project.Name))
-        {
-            this.notificationMessageService.Create(
-                "Name is required!",
-                "Save Project",
-                NotificationType.Error
-            );
-
-            return false;
-        }
-
-        if (String.IsNullOrEmpty(Project.Path) || String.IsNullOrWhiteSpace(Project.Path))
-        {
-            this.notificationMessageService.Create(
-                "Path is required!",
-                "Save Project",
-                NotificationType.Error
-            );
-
-            return false;
-        }
-
-        return true;
     }
 
     private async void DeleteItem()

--- a/UI/MainWindows/MainWindowViewModel.cs
+++ b/UI/MainWindows/MainWindowViewModel.cs
@@ -117,7 +117,7 @@ namespace UI.MainWindows
         private void OpenProjectsWindow()
         {
             var mainWindow = serviceProvider.GetService<IProjectsWindow>() as ProjectsWindow;
-            
+            selectedProjectService.Reset();
             mainWindow!.ShowDialog();
         }
 

--- a/UI/Shared/Services/SelectedProjectService.cs
+++ b/UI/Shared/Services/SelectedProjectService.cs
@@ -10,6 +10,7 @@ namespace UI.Shared.Services
     public interface ISelectedProjectService
     {
         ProjectViewModel GetSelectedProject();
+        void Reset();
         void SetSelectedProject(ProjectViewModel project);
     }
 
@@ -20,6 +21,11 @@ namespace UI.Shared.Services
         public ProjectViewModel GetSelectedProject()
         {
             return this.selectedProject;
+        }
+
+        public void Reset()
+        {
+            this.selectedProject = new();
         }
 
         public void SetSelectedProject(ProjectViewModel project)


### PR DESCRIPTION
This pull request introduces improved validation and error handling for project creation and editing, as well as enhancements to the `SelectedProjectService`. The most significant changes include making field validation asynchronous with proper duplicate name checks, displaying error notifications when validation or service calls fail, and adding the ability to reset the selected project. Associated unit tests have also been updated and expanded to cover these scenarios.

### Project validation and error handling

* Changed `ValidateFields()` in `ProjectsWindowViewModel` to be asynchronous, now fetching all projects before validating, and added a check to prevent duplicate project names. If a duplicate is found, an error notification is shown. [[1]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67L196-R200) [[2]](diffhunk://#diff-b7e683a6bef2d39325d78afb360752f329a61131a7ce969684d88653e101aa67R223-R236)
* Updated error handling in `ValidateFields()` to catch exceptions from service calls and display an error notification with the exception message.
* Modified the `Window_Loaded` event handler in `ProjectsWindow.xaml.cs` to call `LoadDevApps()` asynchronously.

### Unit test improvements

* Updated and added tests in `ProjectsWindowViewModelTests.cs` to verify duplicate name validation and error notification behavior when validation fails or service calls throw exceptions. [[1]](diffhunk://#diff-81a14f5c66785fd01d05bc2270fbea2cc0d1e170b14c69ca307cb2a9fd644884L194-R251) [[2]](diffhunk://#diff-81a14f5c66785fd01d05bc2270fbea2cc0d1e170b14c69ca307cb2a9fd644884R296-R335)

### Selected project management

* Added a `Reset()` method to `SelectedProjectService` and its interface, allowing the selected project to be cleared. [[1]](diffhunk://#diff-ff58804a0fbcb5d72303e17feb0c3a649bccffa5db0136631a33af1131102e8dR13) [[2]](diffhunk://#diff-ff58804a0fbcb5d72303e17feb0c3a649bccffa5db0136631a33af1131102e8dR26-R30)
* Updated `MainWindowViewModel` to reset the selected project before opening the projects window.
* Added a unit test for the new reset functionality in `SelectedProjectServiceTests.cs`.